### PR TITLE
table/message.go : Support for single update for IPV4 VPN prefixes

### DIFF
--- a/table/message.go
+++ b/table/message.go
@@ -476,10 +476,143 @@ func newPackerV4(f bgp.RouteFamily) *packerV4 {
 	}
 }
 
+type packerVPNV4 struct {
+	packer
+	hashmap     map[string][]*cage
+	paths       []*Path
+	withdrawals []*Path
+}
+
+func (p *packerVPNV4) add(path *Path) {
+	p.packer.total++
+
+	if path.IsEOR() {
+		p.packer.eof = true
+		return
+	}
+
+	if path.IsWithdraw {
+		p.withdrawals = append(p.withdrawals, path)
+		return
+	}
+
+	rd := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).RD.String()
+	key := rd + ":" + path.GetNexthop().String()
+	attrsB := bytes.NewBuffer(make([]byte, 0))
+
+	for _, v := range path.GetPathAttrs() {
+		switch v.GetType() {
+		case bgp.BGP_ATTR_TYPE_MP_REACH_NLRI:
+			continue
+		default:
+			b, _ := v.Serialize()
+			attrsB.Write(b)
+		}
+	}
+
+	if cages, y := p.hashmap[key]; y {
+		added := false
+		for _, c := range cages {
+			if bytes.Compare(c.attrsBytes, attrsB.Bytes()) == 0 {
+				c.paths = append(c.paths, path)
+				added = true
+				break
+			}
+		}
+		if !added {
+			p.hashmap[key] = append(p.hashmap[key], newCage(attrsB.Bytes(), path))
+		}
+	} else {
+		p.hashmap[key] = []*cage{newCage(attrsB.Bytes(), path)}
+	}
+}
+
+func (p *packerVPNV4) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
+	split := func(paths []*Path) ([]bgp.PathAttributeInterface, []*Path) {
+		attrs := make([]bgp.PathAttributeInterface, 0, len(paths[0].GetPathAttrs()))
+		mprnlris := make([]bgp.AddrPrefixInterface, 0, len(paths))
+		for _, a := range paths[0].GetPathAttrs() {
+			if a.GetType() != bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
+				attrs = append(attrs, a)
+			}
+		}
+		attrsLen := 0
+		for _, a := range attrs {
+			attrsLen += a.Len()
+		}
+		total := (19 + 2 + 2 + attrsLen)
+		i := 0
+		for _, path := range paths {
+			oattrs := path.GetPathAttrs()
+			for _, a := range oattrs {
+				if a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
+					total = total + a.Len()
+					if total > bgp.BGP_MAX_MESSAGE_LENGTH {
+						attrs = append(attrs, bgp.NewPathAttributeMpReachNLRI(paths[0].GetNexthop().String(), mprnlris))
+						return attrs, paths[i:]
+					} else {
+						mprnlris = append(mprnlris, path.GetNlri())
+						i++
+					}
+				}
+			}
+		}
+
+		attrs = append(attrs, bgp.NewPathAttributeMpReachNLRI(paths[0].GetNexthop().String(), mprnlris))
+		return attrs, paths[i:]
+	}
+
+	loop := func(paths []*Path, cb func([]bgp.PathAttributeInterface)) {
+		var attribs []bgp.PathAttributeInterface
+		for {
+			if len(paths) == 0 {
+				break
+			}
+			attribs, paths = split(paths)
+			cb(attribs)
+		}
+	}
+
+	msgs := make([]*bgp.BGPMessage, 0, p.packer.total)
+
+	for _, path := range p.withdrawals {
+		nlris := []bgp.AddrPrefixInterface{path.GetNlri()}
+		msgs = append(msgs, bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{bgp.NewPathAttributeMpUnreachNLRI(nlris)}, nil))
+	}
+
+	for _, cages := range p.hashmap {
+		for _, c := range cages {
+			paths := c.paths
+			loop(paths, func(attribs []bgp.PathAttributeInterface) {
+				msgs = append(msgs, bgp.NewBGPUpdateMessage(nil, attribs, nil))
+			})
+
+		}
+	}
+
+	if p.eof {
+		msgs = append(msgs, bgp.NewEndOfRib(p.family))
+	}
+	return msgs
+}
+
+func newPackerVPNV4(f bgp.RouteFamily) *packerVPNV4 {
+	return &packerVPNV4{
+		packer: packer{
+			family: f,
+		},
+		hashmap:     make(map[string][]*cage),
+		withdrawals: make([]*Path, 0),
+		paths:       make([]*Path, 0),
+	}
+}
+
 func newPacker(f bgp.RouteFamily) packerInterface {
 	switch f {
 	case bgp.RF_IPv4_UC:
 		return newPackerV4(bgp.RF_IPv4_UC)
+	case bgp.RF_IPv4_VPN:
+		return newPackerVPNV4(bgp.RF_IPv4_VPN)
 	default:
 		return newPackerMP(f)
 	}


### PR DESCRIPTION
Addes support for sending single update for IPV4 VPN prefixes that have same rd and nexthop.